### PR TITLE
Update path to model files when restoring to be relative

### DIFF
--- a/predict_1.py
+++ b/predict_1.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Niek Temme. 
+# Copyright 2016 Niek Temme.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ def predictint(imvalue):
     This function returns the predicted integer.
     The input is the pixel values from the imageprepare() function.
     """
-    
+
     # Define the model (same as when creating the model file)
     x = tf.placeholder(tf.float32, [None, 784])
     W = tf.Variable(tf.zeros([784, 10]))
@@ -43,7 +43,7 @@ def predictint(imvalue):
 
     init_op = tf.initialize_all_variables()
     saver = tf.train.Saver()
-    
+
     """
     Load the model.ckpt file
     file is stored in the same directory as this python script is started
@@ -54,9 +54,9 @@ def predictint(imvalue):
     """
     with tf.Session() as sess:
         sess.run(init_op)
-        saver.restore(sess, "model.ckpt")
+        saver.restore(sess, "./model.ckpt")
         #print ("Model restored.")
-   
+
         prediction=tf.argmax(y,1)
         return prediction.eval(feed_dict={x: [imvalue]}, session=sess)
 
@@ -70,7 +70,7 @@ def imageprepare(argv):
     width = float(im.size[0])
     height = float(im.size[1])
     newImage = Image.new('L', (28, 28), (255)) #creates white canvas of 28x28 pixels
-    
+
     if width > height: #check which dimension is bigger
         #Width is bigger. Width becomes 20 pixels.
         nheight = int(round((20.0/width*height),0)) #resize height according to ratio width
@@ -81,7 +81,7 @@ def imageprepare(argv):
         wtop = int(round(((28 - nheight)/2),0)) #caculate horizontal pozition
         newImage.paste(img, (4, wtop)) #paste resized image on white canvas
     else:
-        #Height is bigger. Heigth becomes 20 pixels. 
+        #Height is bigger. Heigth becomes 20 pixels.
         nwidth = int(round((20.0/height*width),0)) #resize width according to ratio height
         if (nwidth == 0): #rare case but minimum is 1 pixel
             nwidth = 1
@@ -89,13 +89,13 @@ def imageprepare(argv):
         img = im.resize((nwidth,20), Image.ANTIALIAS).filter(ImageFilter.SHARPEN)
         wleft = int(round(((28 - nwidth)/2),0)) #caculate vertical pozition
         newImage.paste(img, (wleft, 4)) #paste resized image on white canvas
-    
+
     #newImage.save("sample.png")
 
     tv = list(newImage.getdata()) #get pixel values
-    
+
     #normalize pixels to 0 and 1. 0 is pure white, 1 is pure black.
-    tva = [ (255-x)*1.0/255.0 for x in tv] 
+    tva = [ (255-x)*1.0/255.0 for x in tv]
     return tva
     #print(tva)
 
@@ -106,6 +106,6 @@ def main(argv):
     imvalue = imageprepare(argv)
     predint = predictint(imvalue)
     print (predint[0]) #first value in list
-    
+
 if __name__ == "__main__":
     main(sys.argv[1])

--- a/predict_2.py
+++ b/predict_2.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Niek Temme. 
+# Copyright 2016 Niek Temme.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,56 +34,56 @@ def predictint(imvalue):
     This function returns the predicted integer.
     The imput is the pixel values from the imageprepare() function.
     """
-    
+
     # Define the model (same as when creating the model file)
     x = tf.placeholder(tf.float32, [None, 784])
     W = tf.Variable(tf.zeros([784, 10]))
     b = tf.Variable(tf.zeros([10]))
-    
+
     def weight_variable(shape):
       initial = tf.truncated_normal(shape, stddev=0.1)
       return tf.Variable(initial)
-    
+
     def bias_variable(shape):
       initial = tf.constant(0.1, shape=shape)
       return tf.Variable(initial)
-       
+
     def conv2d(x, W):
       return tf.nn.conv2d(x, W, strides=[1, 1, 1, 1], padding='SAME')
-    
+
     def max_pool_2x2(x):
-      return tf.nn.max_pool(x, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='SAME')   
-    
+      return tf.nn.max_pool(x, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='SAME')
+
     W_conv1 = weight_variable([5, 5, 1, 32])
     b_conv1 = bias_variable([32])
-    
+
     x_image = tf.reshape(x, [-1,28,28,1])
     h_conv1 = tf.nn.relu(conv2d(x_image, W_conv1) + b_conv1)
     h_pool1 = max_pool_2x2(h_conv1)
-    
+
     W_conv2 = weight_variable([5, 5, 32, 64])
     b_conv2 = bias_variable([64])
-    
+
     h_conv2 = tf.nn.relu(conv2d(h_pool1, W_conv2) + b_conv2)
     h_pool2 = max_pool_2x2(h_conv2)
-    
+
     W_fc1 = weight_variable([7 * 7 * 64, 1024])
     b_fc1 = bias_variable([1024])
-    
+
     h_pool2_flat = tf.reshape(h_pool2, [-1, 7*7*64])
     h_fc1 = tf.nn.relu(tf.matmul(h_pool2_flat, W_fc1) + b_fc1)
-    
+
     keep_prob = tf.placeholder(tf.float32)
     h_fc1_drop = tf.nn.dropout(h_fc1, keep_prob)
-    
+
     W_fc2 = weight_variable([1024, 10])
     b_fc2 = bias_variable([10])
-    
+
     y_conv=tf.nn.softmax(tf.matmul(h_fc1_drop, W_fc2) + b_fc2)
-    
+
     init_op = tf.initialize_all_variables()
     saver = tf.train.Saver()
-    
+
     """
     Load the model2.ckpt file
     file is stored in the same directory as this python script is started
@@ -94,9 +94,9 @@ def predictint(imvalue):
     """
     with tf.Session() as sess:
         sess.run(init_op)
-        saver.restore(sess, "model2.ckpt")
+        saver.restore(sess, "./model2.ckpt")
         #print ("Model restored.")
-       
+
         prediction=tf.argmax(y_conv,1)
         return prediction.eval(feed_dict={x: [imvalue],keep_prob: 1.0}, session=sess)
 
@@ -110,18 +110,18 @@ def imageprepare(argv):
     width = float(im.size[0])
     height = float(im.size[1])
     newImage = Image.new('L', (28, 28), (255)) #creates white canvas of 28x28 pixels
-    
+
     if width > height: #check which dimension is bigger
         #Width is bigger. Width becomes 20 pixels.
         nheight = int(round((20.0/width*height),0)) #resize height according to ratio width
         if (nheigth == 0): #rare case but minimum is 1 pixel
-            nheigth = 1  
+            nheigth = 1
         # resize and sharpen
         img = im.resize((20,nheight), Image.ANTIALIAS).filter(ImageFilter.SHARPEN)
         wtop = int(round(((28 - nheight)/2),0)) #caculate horizontal pozition
         newImage.paste(img, (4, wtop)) #paste resized image on white canvas
     else:
-        #Height is bigger. Heigth becomes 20 pixels. 
+        #Height is bigger. Heigth becomes 20 pixels.
         nwidth = int(round((20.0/height*width),0)) #resize width according to ratio height
         if (nwidth == 0): #rare case but minimum is 1 pixel
             nwidth = 1
@@ -129,13 +129,13 @@ def imageprepare(argv):
         img = im.resize((nwidth,20), Image.ANTIALIAS).filter(ImageFilter.SHARPEN)
         wleft = int(round(((28 - nwidth)/2),0)) #caculate vertical pozition
         newImage.paste(img, (wleft, 4)) #paste resized image on white canvas
-    
+
     #newImage.save("sample.png")
 
     tv = list(newImage.getdata()) #get pixel values
-    
+
     #normalize pixels to 0 and 1. 0 is pure white, 1 is pure black.
-    tva = [ (255-x)*1.0/255.0 for x in tv] 
+    tva = [ (255-x)*1.0/255.0 for x in tv]
     return tva
     #print(tva)
 
@@ -146,6 +146,6 @@ def main(argv):
     imvalue = imageprepare(argv)
     predint = predictint(imvalue)
     print (predint[0]) #first value in list
-    
+
 if __name__ == "__main__":
     main(sys.argv[1])


### PR DESCRIPTION
The prediction scripts fail for me with the following error:

`NotFoundError (see above for traceback): Unsuccessful TensorSliceReader constructor: Failed to find any matching files for model.ckpt
	 [[Node: save/RestoreV2 = RestoreV2[dtypes=[DT_FLOAT], _device="/job:localhost/replica:0/task:0/cpu:0"](_recv_save/Const_0, save/RestoreV2/tensor_names, save/RestoreV2/shape_and_slices)]]`

Changing the path to the model.ckpt file from 'model.ckpt' to './model.ckpt' when restoring seems to be fixing the issue for me.